### PR TITLE
Fix Autoprefixer warning message while compiling CSS

### DIFF
--- a/assets/css/dev/postcss.config.js
+++ b/assets/css/dev/postcss.config.js
@@ -15,8 +15,7 @@ module.exports = {
         require('postcss-import')({
             path: [themeDir]
         }), 
-        require('tailwindcss')(themeDir + 'assets/css/tailwind.config.js'),   
-        require('autoprefixer')({
-        }),
+        require('tailwindcss')(themeDir + 'assets/css/tailwind.config.js'),
+        require('autoprefixer'),
     ]
 }

--- a/assets/css/dev/postcss.config.js
+++ b/assets/css/dev/postcss.config.js
@@ -17,7 +17,6 @@ module.exports = {
         }), 
         require('tailwindcss')(themeDir + 'assets/css/tailwind.config.js'),   
         require('autoprefixer')({
-            browsers: ['>1%']
         }),
     ]
 }

--- a/assets/css/postcss.config.js
+++ b/assets/css/postcss.config.js
@@ -26,8 +26,7 @@ module.exports = {
             fontFace: true
         }),    
         require('autoprefixer')({
-            grid: true,
-            browsers: ['>1%']
+            grid: true
         }),
         require('postcss-reporter'),
     ]

--- a/package.json
+++ b/package.json
@@ -16,5 +16,11 @@
         "postcss-cli": "^6.1.2",
         "postcss-import": "^12.0.1",
         "tailwindcss": "^1.0.4"
-    }
+    },
+    "browserslist": [
+        "last 1 version",
+        "> 1%",
+        "maintained node versions",
+        "not dead"
+    ]
 }


### PR DESCRIPTION
To fix the following warning while compiling CSS...

>   Replace Autoprefixer browsers option to Browserslist config.
>   Use browserslist key in package.json or .browserslistrc file.
> 
>   Using browsers option cause some error. Browserslist config
>   can be used for Babel, Autoprefixer, postcss-normalize and other tools.
> 
>   If you really need to use option, rename it to overrideBrowserslist.
> 
>   Learn more at:
>   https://github.com/browserslist/browserslist#readme
>   https://twitter.com/browserslist

Alternative solution is to create a new `.browserslistrc` file with the following content...

```
# Browsers that we support
last 1 version
> 1%
maintained node versions
not dead
```

Unfortunately, we can not use both `package.json` and `.browserslistrc` file. In this case, we'd get another error...

> BrowserslistError: /path/to/hugo/site contains both .browserslistrc and package.json with browsers