### PR TITLE
Deactivate purging of Tailwind base classes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,8 +1,11 @@
+/* purgecss start ignore */
 /* Tailwind base - put variables under: tailwind.config.js */
 @import "node_modules/tailwindcss/base";
 /* Tailwind component classes registered by plugins*/
 @import "node_modules/tailwindcss/components";
 /* Site Specific */
 @import "assets/css/site";
+/* purgecss end ignore */
+
 /* Tailwind's utility classes - generated based on config file */
 @import "node_modules/tailwindcss/utilities";


### PR DESCRIPTION
I had issues (#30) where base classes were purged so I let PurgeCSS ignore the site styling as well as the Tailwind basics.

(First time trying pull requests. Please review and let me know if it works or if there is a simpler solution.)