### PR TITLE
Fix content resolving for running 'hugo server' command from base dir

### DIFF
--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   content: [
+    "./themes/**/layouts/**/*.html",
+    "./content/**/layouts/**/*.html",
     "./layouts/**/*.html",
     "./content/**/*.html"
   ],


### PR DESCRIPTION
This pull fixes an issue where the `tailwind.config.js`'s `content` couldn't be resolved correctly, when running the command `hugo server` from the base dir of a Hugo project.

**Steps to reproduce:**

1. Create a new Hugo site `hugo new site test`
2. Clone tailwindcss-starter theme `cd test/themes && git clone https://github.com/dirkolbrich/hugo-theme-tailwindcss-starter.git tailwind`
3. Change `config.toml` to use `theme = 'tailwind'`
4. Change dir back to `test` and run `hugo server -D`
5. CSS is not loaded correctly

<img width="1552" alt="Bildschirmfoto 2022-02-27 um 11 29 35" src="https://user-images.githubusercontent.com/6780575/155879105-9fbb7fea-e622-4638-9f13-7b832c50a5fc.png">

After applying the fix, everything works as expected when running `hugo server -D` from the site's base dir.

<img width="1552" alt="Bildschirmfoto 2022-02-27 um 11 30 31" src="https://user-images.githubusercontent.com/6780575/155879183-1ff1dde7-b6dd-42b4-9bc2-6b0406fc10ea.png">

