### PR TITLE
Fixed minify and fingerprint for production/export

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -2,6 +2,6 @@
 {{- if .Site.IsServer }}
 {{ $styles = $styles | resources.ExecuteAsTemplate (printf "css/styles.dev.%v.css" now.UnixMilli) .}}
 {{ else }}
-{{- $styles := $styles| minify | fingerprint | resources.PostProcess -}}
+{{ $styles = $styles | minify | fingerprint | resources.PostProcess }}
 {{ end -}}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}">


### PR DESCRIPTION
Before minify and fingerprint was not called resulting in the stylesheet been css/styles.css, it was not minified, not compressed, and not fingerprinted.